### PR TITLE
Do not try to load class when queue is not enabled

### DIFF
--- a/lib/Airbrake/Client.php
+++ b/lib/Airbrake/Client.php
@@ -93,7 +93,7 @@ class Client
      */
     public function notify(Notice $notice)
     {
-        if (class_exists('Resque') && $this->configuration->queue) {
+        if ($this->configuration->queue && class_exists('Resque')) {
             $data = array('notice' => serialize($notice), 'configuration' => serialize($this->configuration));
             \Resque::enqueue($this->configuration->queue, 'Airbrake\\Resque\\NotifyJob', $data);
             return;


### PR DESCRIPTION
This fixes a warning thrown by autoloader when the class can not be located.