### PR TITLE
Log exceptions, warnings and errors logged with Mage::log 

### DIFF
--- a/app/code/community/Elgentos/CodebaseExceptions/Model/Log/Writer/Stream.php
+++ b/app/code/community/Elgentos/CodebaseExceptions/Model/Log/Writer/Stream.php
@@ -1,0 +1,23 @@
+<?php
+
+class Elgentos_CodebaseExceptions_Model_Log_Writer_Stream extends Zend_Log_Writer_Stream
+{
+    /**
+     * Write a message to the log.
+     *
+     * @param  array  $event  event data
+     * @return void
+     * @throws Zend_Log_Exception
+     */
+    protected function _write($event)
+    {
+        $line = $this->_formatter->format($event);
+
+        if ($event['priority'] <= Zend_Log::WARN) {
+            Mage::helper('codebaseexceptions')->sendToAirbrake($event['message'], 4);
+        }
+        if (false === @fwrite($this->_stream, $line)) {
+            throw new Zend_Log_Exception("Unable to write to stream");
+        }
+    }
+}

--- a/app/code/community/Elgentos/CodebaseExceptions/controllers/IndexController.php
+++ b/app/code/community/Elgentos/CodebaseExceptions/controllers/IndexController.php
@@ -2,6 +2,9 @@
 class Elgentos_CodebaseExceptions_IndexController extends Mage_Core_Controller_Front_Action {
 
     public function testAction() {
+        Mage::logException( new Exception('This is just a test exception to check whether the extension can handle logged exception'));
+        Mage::log('This is just a test to check whether the extension can handle single line warning logged to Magento log', Zend_Log::WARN);
+        Mage::log("This is just a test\nto check whether the extension can handle multiline warning \nlogged to Magento log", Zend_Log::WARN);
         throw new Exception('This is just a test exception to check whether the extension is working.');
     }
 

--- a/app/code/community/Elgentos/CodebaseExceptions/etc/config.xml
+++ b/app/code/community/Elgentos/CodebaseExceptions/etc/config.xml
@@ -55,6 +55,16 @@
                 <class>Elgentos_CodebaseExceptions_Helper</class>
             </codebaseexceptions>
         </helpers>
+        <models>
+            <codebaseexceptions>
+                <class>Elgentos_CodebaseExceptions_Model</class>
+            </codebaseexceptions>
+        </models>
+        <log>
+            <core>
+                <writer_model>Elgentos_CodebaseExceptions_Model_Log_Writer_Stream</writer_model>
+            </core>
+        </log>
     </global>
 
     <default>

--- a/app/etc/modules/Elgentos_CodebaseExceptions.xml
+++ b/app/etc/modules/Elgentos_CodebaseExceptions.xml
@@ -4,6 +4,9 @@
 			<Elgentos_CodebaseExceptions>
 				<active>true</active>
 				<codePool>community</codePool>
+				<depends>
+					<Mage_Core/>
+				</depends>
 			</Elgentos_CodebaseExceptions>
 		</modules>
 	</config>


### PR DESCRIPTION
and Mage::logException.

This change logs to airbrake everything which was logged in Magento using Magento::logException()
or Mage::log with severity (EMERG, ALERT, CRIT, ERR and WARN).
It does NOT log calls like
Mage::log('something');
As the default severity is DEBUG in that case.
You can test this change with code like:
```
try {
Mage::throwException("test");
} catch(Exception $e) {
Mage::logException($e);
}
```

you should see the exception being logged into airbrake