### PR TITLE
modman: link processor.php from Magento to our dir

### DIFF
--- a/modman
+++ b/modman
@@ -2,3 +2,5 @@ app/code/community/Elgentos/CodebaseExceptions app/code/community/Elgentos/Codeb
 app/etc/modules/* app/etc/modules/
 errors/report.php errors/report.php
 lib/Airbrake lib/Airbrake
+
+@shell ln -s $PROJECT/errors/processor.php $MODULE/errors/processor.php


### PR DESCRIPTION
Replaces #3 (Copy report.php instead of linking it, to avoid relative
path problems with symlinks in require statement)

This avoids the problem when `require_once` in `errors/report.php`
cannot find `processor.php` in our directory and fails with this reason:

    Fatal error: require_once(): Failed opening required 'processor.php'