### PR TITLE
Data: fix error about undefined offset in array

### DIFF
--- a/app/code/community/Elgentos/CodebaseExceptions/Helper/Data.php
+++ b/app/code/community/Elgentos/CodebaseExceptions/Helper/Data.php
@@ -30,7 +30,11 @@ class Elgentos_CodebaseExceptions_Helper_Data extends Mage_Core_Helper_Abstract 
         foreach($backtraceLines as $backtrace) {
             $temp = array();
             $parts = explode(': ',$backtrace);
-            $temp['function'] = $parts[1];
+
+            if (isset($parts[1])) {
+                $temp['function'] = $parts[1];
+            }
+
             $temp['file'] = substr($parts[0],0,stripos($parts[0],'('));
             $temp['line'] = substr($parts[0],stripos($parts[0],'(')+1,(stripos($parts[0],')')-1)-stripos($parts[0],'('));
 


### PR DESCRIPTION
The error is:

    ERR (3): Notice: Undefined offset: 1 in ...

It is caused by backtraces that contain frames such as this one:

    Array ( [0] => #6 {main} )

...which is an example of the first frame of every backtrace.